### PR TITLE
Fix/remove save reload

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -3159,12 +3159,13 @@ proxyip.cmliussss.net" class="w-full px-4 py-3 rounded-xl border border-slate-20
 
           async function doSave() {
               const el = id => document.getElementById(id);
+              const prevApiRoute = (window.nahanConfig && window.nahanConfig.apiRoute) || baseRoute.replace(/^\//, '');
               const payload = {
                   key: sessionKey,
                   config: {
                       mode: el('cfg-proto').value, socketPorts: Array.from(el('cfg-port').selectedOptions).map(o=>o.value).join(','), deviceId: el('cfg-uuid').value,
                       apiRoute: el('cfg-path').value, masterKey: el('cfg-pass').value, agent: el('cfg-fp').value,
-                      resolveIp: el('cfg-dns').value, customDns: el('cfg-custom-dns').value ? el('cfg-custom-dns').value : 'https://cloudflare-dns.com/dns-query', cleanIps: el('cfg-ips').value, maintenanceHost: el('cfg-fake') ? el('cfg-fake').value : '', backupRelay: el('cfg-relay').value, customRouting: el('cfg-custom-routing') ? el('cfg-custom-routing').value : '',  nat64Prefix: el('cfg-nat64') ? el('cfg-nat64').value : '', enableDirectConfigs: el('cfg-direct-configs') ? el('cfg-direct-configs').checked : false, syncApiKey: el('cfg-sync-api-key') ? el('cfg-sync-api-key').value.trim() : '', autoUpdate: el('cfg-auto-update') ? el('cfg-auto-update').checked : false, autoUpdateFormat: document.querySelector('input[name="auto-update-format"]:checked')?.value || 'normal',
+                      resolveIp: el('cfg-dns').value, customDns: el('cfg-custom-dns').value ? el('cfg-custom-dns').value : 'https://cloudflare-dns.com/dns-query', cleanIps: el('cfg-ips').value, maintenanceHost: el('cfg-fake') ? el('cfg-fake').value : '', backupRelay: el('cfg-relay').value, customRouting: el('cfg-custom-routing') ? el('cfg-custom-routing').value : '',  nat64Prefix: el('cfg-nat64') ? el('cfg-nat64').value : '', enableDirectConfigs: el('cfg-direct-configs') ? el('cfg-direct-configs').checked : false, syncApiKey: el('cf...ey') ? el('cfg-sync-api-key').value.trim() : '', autoUpdate: el('cfg-auto-update') ? el('cfg-auto-update').checked : false, autoUpdateFormat: document.querySelector('input[name="auto-update-format"]:checked')?.value || 'normal',
                       enableOpt1: el('cfg-tfo').checked, enableOpt2: el('cfg-ech').checked,
                       tgToken: el('cfg-tg-token').value, tgChatId: el('cfg-tg-chat').value, tgAdminId: el('cfg-tg-admin').value,
                       cfAccountId: el('cfg-cf-acc').value, cfApiToken: el('cfg-cf-token').value,
@@ -3214,7 +3215,19 @@ proxyip.cmliussss.net" class="w-full px-4 py-3 rounded-xl border border-slate-20
                               }).then(r => { if (!r.ok) console.error('Sync to ' + h + ' failed: HTTP ' + r.status); }).catch(e => { console.error('Sync to ' + h + ' error:', e.message); });
                           });
                       }
-                      setTimeout(() => window.location.href = '/' + data.newRoute + '/dash', 1000);
+                      // Update local config with saved values
+                      Object.assign(window.nahanConfig, payload.config);
+                      const newApiRoute = data.newRoute || payload.config.apiRoute;
+                      if (newApiRoute && newApiRoute !== prevApiRoute) {
+                          // API route changed — must redirect to new URL
+                          baseRoute = '/' + newApiRoute;
+                          setTimeout(() => { window.location.href = '/' + newApiRoute + '/dash'; }, 1000);
+                      } else {
+                          // Same route — just refresh data silently, no reload
+                          baseRoute = '/' + (newApiRoute || prevApiRoute);
+                          doLogin(true);
+                          setTimeout(() => { stat.textContent = ''; }, 2500);
+                      }
                   } else { stat.textContent = i18n[lang].msg_err; stat.className = "text-sm font-bold text-red-500 md:me-4"; }
               } catch(e) { stat.textContent = i18n[lang].msg_err; stat.className = "text-sm font-bold text-red-500 md:me-4"; }
           }
@@ -4013,7 +4026,7 @@ function buildPortCheckboxes(wrapId, selectedPorts) {
                   });
                   if(res.ok) {
                        const stat = document.getElementById('save-status');
-                       stat.textContent = "Saved. Refreshing...";
+                       stat.textContent = "Saved!";
                        setTimeout(() => { doLogin(true); stat.textContent = ""; }, 1000);
                   }
               } catch(e) {}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1856,7 +1856,7 @@ proxyip.cmliussss.net" class="w-full px-4 py-3 rounded-xl border border-slate-20
                   modal_add_title: "Add New User", lbl_u_name: "Name (Required)", lbl_u_gb: "Traffic Limit (GB) - Optional", lbl_u_days: "Duration (Days) - Optional", btn_cancel: "Cancel", btn_confirm: "Add User",
                   limit_total: "Traffic (GB) Limit (Leave empty for unlimited)", limit_daily: "Daily Requests Limit (Leave empty for unlimited)",
                   limit_days: "Expiration limit (Days) - Leave empty for unlimited", edit_sub: "Edit Subscriber", lbl_name_ph: "Name or UUID",
-                  btn_save_changes: "Save Changes", save_btn_user: "Save User", save_btn: "Save Config", status_active: "Active", status_paused: "Paused", status_expired: "Expired",
+                  btn_save_changes: "Save Changes", save_btn_user: "Save User", save_btn: "Save Config", msg_saving: "Saving...", msg_saved: "Saved!", msg_err: "Connection Error", status_active: "Active", status_paused: "Paused", status_expired: "Expired",
                   stat_total_subscribers: "Total Subscribers", stat_active_paused: "Active / Paused", stat_cumulative_traffic: "Cumulative Traffic", stat_auto_disabled: "Auto-Disabled",
                   sub_directory_title: "Subscriber Directory", sub_directory_desc: "Search, modify bounds, toggle traffic limits or clear billing sessions.", user_search_placeholder: "🔍 Find by Name or UUID...",
                   filter_all: "All Users", filter_active: "Active", filter_paused: "Paused", filter_auto_disabled: "Auto-Disabled",
@@ -1951,7 +1951,7 @@ proxyip.cmliussss.net" class="w-full px-4 py-3 rounded-xl border border-slate-20
                   user_mgt_title: "مدیریت کاربران", user_mgt_desc: "مدیریت کاربران متعدد، تنظیم محدودیت ترافیک، و تاریخ انقضا.", btn_add_user: "+ افزودن کاربر جدید",
                   tbl_name: "نام", tbl_uuid: "شناسه یکتا", tbl_traffic: "ترافیک (مصرفی/محدودیت)", tbl_exp: "انقضا", tbl_action: "عملیات", no_users: "کاربری یافت نشد. از دکمه بالا یک کاربر ایجاد کنید.",
                   modal_add_title: "افزودن کاربر جدید", lbl_u_name: "نام (الزامی)", lbl_u_gb: "محدودیت ترافیک (گیگابایت) - اختیاری", lbl_u_days: "مدت زمان اعتبار (روز) - اختیاری", btn_cancel: "انصراف", btn_confirm: "افزودن کاربر",
-                  save_btn: "ذخیره تنظیمات", msg_saving: "در حال ثبت...", msg_saved: "موفق! در حال بارگذاری...", msg_err: "خطای ارتباط",
+                  save_btn: "ذخیره تنظیمات", msg_saving: "در حال ثبت...", msg_saved: "موفق!", msg_err: "خطای ارتباط",
                   backup_restore_title: "پشتیبان‌گیری و بازیابی", ping_test_title: "عیب‌یابی تاخیر شبکه", ping_test_desc: "تاخیر پاسخ‌دهی را به آی‌پی تمیز فعال اندازه بگیرید.",
                   lbl_github_repo: "مخزن منبع جهت بروزرسانی", update_avail: "بروزرسانی جدید در دسترس است!", update_btn: "دریافت آخرین کد",
                     cf_help_title: "آموزش بدست آوردن این اطلاعات برای کاربران مبتدی",
@@ -4026,7 +4026,7 @@ function buildPortCheckboxes(wrapId, selectedPorts) {
                   });
                   if(res.ok) {
                        const stat = document.getElementById('save-status');
-                       stat.textContent = "Saved!";
+                       stat.textContent = i18n[lang]?.msg_saved || "Saved!";
                        setTimeout(() => { doLogin(true); stat.textContent = ""; }, 1000);
                   }
               } catch(e) {}


### PR DESCRIPTION
fix(dashboard): prevent unnecessary page reload after saving config

Previously, the dashboard always redirected after clicking 'Save Config',
even when the API route hadn't changed. This caused a disruptive full
page reload on every save.

Changes:
- Only redirect when the API route actually changes
- Silently refresh data via API when route is unchanged
- Add missing i18n keys (msg_saving, msg_saved, msg_err) for English
- Update Farsi msg_saved to remove misleading 'در حال بارگذاری...'